### PR TITLE
Adding Dex Order Functionality

### DIFF
--- a/src/pokemon.lua
+++ b/src/pokemon.lua
@@ -15,10 +15,12 @@ local function load_pokemon_folder(folder)
         if curr_pokemon.init then curr_pokemon:init() end
 
         local family = {}
+        local orderlist = {}
 
         if curr_pokemon.list and #curr_pokemon.list > 0 then
           for _, item in ipairs(curr_pokemon.list) do
             family[#family + 1] = item.name
+            orderlist[#orderlist+1] = item.name
 
             if (pokermon_config.jokers_only and not item.joblacklist) or not pokermon_config.jokers_only then
               item.discovered = true
@@ -74,6 +76,7 @@ local function load_pokemon_folder(folder)
           if #family > 1 then
             pokermon.add_family(family)
           end
+          if (SMODS.Mods["NachosPokermonDip"] or {}).can_load then PkmnDip.dex_order_groups[#PkmnDip.dex_order_groups+1] = orderlist end
         end
       end
     end


### PR DESCRIPTION
This is all you should need to have your add-on jokers display in dex order when combined with Pokermon Dip and the toggle enabled.