### PR TITLE
fix pokemon_in_pool hook

### DIFF
--- a/src/functions/functions.lua
+++ b/src/functions/functions.lua
@@ -463,9 +463,11 @@ end
 local original_pokemon_in_pool = pokemon_in_pool
 
 function pokemon_in_pool(v)
-  if v and v.tagged == "sonfive" and type(v.in_pool) == "function" then
-    local ok, result = pcall(function() return v:in_pool() end)
-    if ok then return result end
+  if v and v.tagged == "sonfive" then
+    local base_evo_name = sonfive_base_evo_name(v)
+    if not sonfive_config[base_evo_name] then
+      return false
+    end
   end
   return original_pokemon_in_pool(v)
 end

--- a/src/pokemon.lua
+++ b/src/pokemon.lua
@@ -26,17 +26,6 @@ local function load_pokemon_folder(folder)
               item.discovered = true
               if not item.key then item.key = item.name end
 
-              if not pokermon_config.no_evos and not item.custom_pool_func then
-                item.custom_pool_func = true
-                item.in_pool = function(self)
-                  local base_evo_name = sonfive_base_evo_name(self)
-                  if (sonfive_config[base_evo_name]) then
-                    return pokemon_in_pool(self)
-                  end
-                  return false
-                end
-              end
-
               if not item.tagged then
                 item.tagged = "sonfive"
               end


### PR DESCRIPTION
changes the `pokemon_in_pool` hook to return false is a center is tagged 'sonfive' and isn't enabled in the config table

also removes a similar function from the pokemon loader as `pokermon_config.no_evos` is not currently togglable/in use in the base pokermon mod