### PR TITLE
Mega Darkrai fix

### DIFF
--- a/jokerdisplay/definitions9.lua
+++ b/jokerdisplay/definitions9.lua
@@ -13,15 +13,14 @@ jd_def["j_sonfive_mega_darkrai"] = {
     calc_function = function(card)
         local Xmult = card.ability.extra.Xmult_multi or 1
 
-        for _, ptype in pairs(POKE_TYPES) do
-            local energy_key = 'c_poke_'..string.lower(ptype)..(ptype == 'Dark' and 'ness' or '')..'_energy'
-            local energy_type_count = #SMODS.find_card(energy_key)
-            local joker_type_count = #find_pokemon_type(ptype)
-            
-            if energy_type_count > 0 and joker_type_count > 0 then
-                Xmult = Xmult * energy_type_count * joker_type_count
+        if G.consumeables then
+          for _, v in ipairs(G.consumeables.cards) do
+            if v.ability.set == 'poke_energy' and #pokermon.find_pokemon_type(v.config.center.etype) > 0 then
+              Xmult = Xmult * #pokermon.find_pokemon_type(v.config.center.etype)
             end
+          end
         end
+
         card.joker_display_values.x_mult = Xmult
     end
 }

--- a/src/pokemon/491_darkrai_line.lua
+++ b/src/pokemon/491_darkrai_line.lua
@@ -1,10 +1,9 @@
 local darkrai = {
   name = "darkrai",
-  config = {extra = {}},
+  config = { extra = {} },
   loc_vars = function(self, info_queue, card)
-      type_tooltip(self, info_queue, card)
-      info_queue[#info_queue+1] = { set = 'Spectral', key = 'c_poke_nightmare'}
-
+    type_tooltip(self, info_queue, card)
+    info_queue[#info_queue + 1] = { set = 'Spectral', key = 'c_poke_nightmare' }
   end,
   designer = "Sonfive",
   rarity = 4,
@@ -18,11 +17,12 @@ local darkrai = {
       local _card = create_card('Spectral', G.consumeables, nil, nil, nil, nil, 'c_poke_nightmare')
       _card:add_to_deck()
       G.consumeables:emplace(_card)
-      card_eval_status_text(_card, 'extra', nil, nil, nil, {message = localize('k_plus_spectral'), colour = G.C.SECONDARY_SET.Spectral})
+      card_eval_status_text(_card, 'extra', nil, nil, nil,
+        { message = localize('k_plus_spectral'), colour = G.C.SECONDARY_SET.Spectral })
     end
   end,
   calculate = function(self, card, context)
-      -- Spawn Spectral card if conditions are met
+    -- Spawn Spectral card if conditions are met
     --   if not context.repetition and not context.individual and context.end_of_round
     --      and G.GAME.last_blind and G.GAME.last_blind.boss then
     --       if #G.consumeables.cards + G.GAME.consumeable_buffer < G.consumeables.config.card_limit then
@@ -32,119 +32,105 @@ local darkrai = {
     --       end
     --   end
 
-      if not context.blueprint then
-          local darkrai_count = #SMODS.find_card("j_sonfive_darkrai")
+    if not context.blueprint then
+      local darkrai_count = #SMODS.find_card("j_sonfive_darkrai")
 
-          -- Initialize Darkrai's snapshot
-          if not card.ability.extra.darkrai_applied_energy then
-              card.ability.extra.darkrai_applied_energy = {}
-          end
+      -- Initialize Darkrai's snapshot
+      if not card.ability.extra.darkrai_applied_energy then
+        card.ability.extra.darkrai_applied_energy = {}
+      end
 
-          -- Step 1: Calculate desired energy per type
-          for _, ptype in pairs(POKE_TYPES) do
-              local energy_key = 'c_poke_'..string.lower(ptype)..(ptype == 'Dark' and 'ness' or '')..'_energy'
-              local energy_type_count = #SMODS.find_card(energy_key) * darkrai_count
-              card.ability.extra.darkrai_applied_energy[ptype] = energy_type_count
+      -- Step 1: Calculate desired energy per type
+      for _, ptype in pairs(POKE_TYPES) do
+        local energy_key = 'c_poke_' .. string.lower(ptype) .. (ptype == 'Dark' and 'ness' or '') .. '_energy'
+        local energy_type_count = #SMODS.find_card(energy_key) * darkrai_count
+        card.ability.extra.darkrai_applied_energy[ptype] = energy_type_count
 
-              -- Step 2: Apply to jokers
-              for _, joker in ipairs(G.jokers.cards) do
-                local extra = joker.ability and joker.ability.extra
-                if type(extra) == "table" then
-                    joker.ability.extra = joker.ability.extra or {}
-                    if not joker.ability.extra.darkrai_applied then
-                        joker.ability.extra.darkrai_applied = {}
-                    end
-                    local to_apply = card.ability.extra.darkrai_applied_energy[ptype]
-                    local last_applied = joker.ability.extra.darkrai_applied[ptype] or 0
+        -- Step 2: Apply to jokers
+        for _, joker in ipairs(G.jokers.cards) do
+          local extra = joker.ability and joker.ability.extra
+          if type(extra) == "table" then
+            joker.ability.extra = joker.ability.extra or {}
+            if not joker.ability.extra.darkrai_applied then
+              joker.ability.extra.darkrai_applied = {}
+            end
+            local to_apply = card.ability.extra.darkrai_applied_energy[ptype]
+            local last_applied = joker.ability.extra.darkrai_applied[ptype] or 0
 
-                    if is_type(joker, ptype) then
-                        -- Joker matches this type → sync energies
-                        if to_apply ~= last_applied then
-                            local diff = to_apply - last_applied
-                            energize(joker, ptype, nil, true, diff)
-                            joker.ability.extra.darkrai_applied[ptype] = to_apply
-                        end
-                    else
-                        -- Joker no longer this type → remove old Darkrai-applied energy
-                        if last_applied > 0 then
-                            energize(joker, ptype, false, true, -last_applied)
-                            joker.ability.extra.darkrai_applied[ptype] = 0
-                        end
-                    end
-                end
+            if is_type(joker, ptype) then
+              -- Joker matches this type → sync energies
+              if to_apply ~= last_applied then
+                local diff = to_apply - last_applied
+                energize(joker, ptype, nil, true, diff)
+                joker.ability.extra.darkrai_applied[ptype] = to_apply
+              end
+            else
+              -- Joker no longer this type → remove old Darkrai-applied energy
+              if last_applied > 0 then
+                energize(joker, ptype, false, true, -last_applied)
+                joker.ability.extra.darkrai_applied[ptype] = 0
+              end
             end
           end
+        end
       end
+    end
   end,
 
   remove_from_deck = function(self, card, from_debuff)
     for _, card in ipairs(G.jokers.cards) do
-        local extra = card.ability and card.ability.extra
-        if type(extra) == "table" then
-            card.ability.extra = card.ability.extra or {}
-            local applied = card.ability.extra.darkrai_applied or {}
+      local extra = card.ability and card.ability.extra
+      if type(extra) == "table" then
+        card.ability.extra = card.ability.extra or {}
+        local applied = card.ability.extra.darkrai_applied or {}
 
-            for _, ptype in pairs(POKE_TYPES) do
-                local last_applied = applied[ptype] or 0
-                if last_applied > 0 then
-                    energize(card, ptype, false, true, -last_applied)
-                    applied[ptype] = 0
-                end
-            end
+        for _, ptype in pairs(POKE_TYPES) do
+          local last_applied = applied[ptype] or 0
+          if last_applied > 0 then
+            energize(card, ptype, false, true, -last_applied)
+            applied[ptype] = 0
+          end
         end
-        -- Clear Darkrai's own stored snapshot
-        card.ability.extra.darkrai_applied_energy = {}
+      end
+      -- Clear Darkrai's own stored snapshot
+      card.ability.extra.darkrai_applied_energy = {}
     end
   end,
-  megas = {"mega_darkrai"}
+  megas = { "mega_darkrai" }
 }
 
 local mega_darkrai = {
   name = "mega_darkrai",
-  config = {extra = {Xmult_multi = 1}},
+  config = { extra = { Xmult_multi = 1 } },
   loc_vars = function(self, info_queue, card)
-      type_tooltip(self, info_queue, card)
-      local vars = {
-      card.ability.extra.Xmult_multi
-    }
-
-    return {vars = vars}
+    type_tooltip(self, info_queue, card)
+    return { vars = { card.ability.extra.Xmult_multi } }
   end,
   designer = "Sonfive",
   rarity = "poke_mega",
   cost = 20,
   atlas = "sonfive_other",
-  pos = {x = 0, y = 0},
-  soul_pos = {x = 1, y = 0},
+  pos = { x = 0, y = 0 },
+  soul_pos = { x = 1, y = 0 },
   stage = "Mega",
   ptype = "Dark",
   gen = 4,
   blueprint_compat = true,
+  calculate = function(self, card, context)
+    if context.other_consumeable and context.other_consumeable.ability.set == 'poke_energy' then
+      local Xmult = #pokermon.find_pokemon_type(context.other_consumeable.config.center.etype) * card.ability.extra.Xmult_multi
 
-calculate = function(self, card, context)
-    if context.other_consumeable and context.other_consumeable.ability.set == 'Energy' then
-        local Xmult = 0
-        for _, ptype in pairs(POKE_TYPES) do
-            if context.other_consumeable.ability.name == 'c_poke_'..string.lower(ptype)..(ptype == 'Dark' and 'ness' or '')..'_energy' then
-                Xmult = (#find_pokemon_type(ptype) * card.ability.extra.Xmult_multi)
-                break 
-            end
-        end
-        
-        if Xmult > 1 then
-            return {
-                message = localize{type = 'variable', key = 'a_xmult', vars = {Xmult}}, 
-                colour = G.C.XMULT,
-                Xmult_mod = Xmult
-            }
-        end
+      if Xmult > 1 then
+        return { Xmult = Xmult, card = context.other_consumeable }
+      end
     end
-end
+  end
 }
 
 
-local list = {darkrai, mega_darkrai}
+local list = { darkrai, mega_darkrai }
 
-return {name = "Darkrai",
-list = list
+return {
+  name = "Darkrai",
+  list = list
 }


### PR DESCRIPTION
Mega Darkrai wasn't scoring because of the prefixing, so I took the liberty to fix up the code for it (hopefully saving you a lot of iterating through POKE_TYPES, energies also have an 'etype' that goes with a given 'ptype')

Also fixed up the display def for it because the number wasn't quite right

Nothing in regular Darkrai's code actually changes I just hit "format document" in VSCode and it spaced it out neatly